### PR TITLE
Fix pycentral query, updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ dmypy.json
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 .vscode/
 scratch.py
+
+# App ignores
+# ignoring directory where tokens are stored.
+temp/

--- a/cli.py
+++ b/cli.py
@@ -354,7 +354,8 @@ def _refresh_tokens():
     # access token in config is overriden stored in tok file in config dir
     session = CentralApi()
     central = session.central
-    central.token_store["path"] = _config_dir
+    # Commented out as I have no idea what it was doing. Maybe from a previous auth process? -mrose
+    # central.token_store["path"] = _config_dir
     token = central.loadToken()
     if token:
         # refresh token on every launch


### PR DESCRIPTION
Updated .gitignore to ignore temp directory where pycentral stores tokens
Commented out central.token_store["path"] = _config_dir as it was generating an error. It appears to be from a previous auth process. 