### PR TITLE
Added the ability to pass an account name to switch from different Aruba Central accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ dmypy.json
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 .vscode/
 scratch.py
+
+# App ignores
+# ignoring directory where tokens are stored.
+temp/

--- a/cli.py
+++ b/cli.py
@@ -158,7 +158,10 @@ def bulk_edit(input_file: str = typer.Argument(None)):
 
 @app.command()
 def show(what: ShowLevel1 = typer.Argument(...), dev_type: str = typer.Argument(None), group: str = None,
-         json: bool = typer.Option(False, "-j", is_flag=True, help="Output in JSON")):
+        json: bool = typer.Option(False, "-j", is_flag=True, help="Output in JSON"),
+        account: str = typer.Option("central_info", help="Pass the account name from the config file")
+        ):
+    session = _refresh_tokens(account)
     # session = utils.spinner(SPIN_TXT_AUTH, CentralApi)
 
     if not dev_type:
@@ -351,9 +354,9 @@ def refresh_tokens():
     pass
 
 
-def _refresh_tokens():
+def _refresh_tokens(account_name):
     # access token in config is overriden stored in tok file in config dir
-    session = CentralApi()
+    session = CentralApi(account_name)
     central = session.central
 
     # central.token_store["path"] = config.base_dir.joinpath(".token")
@@ -370,8 +373,10 @@ def _refresh_tokens():
 
 log.info("-- Script Starting --", show=False)  # just testing log can remove
 if __name__ == "__main__":
-    session = _refresh_tokens()
+    # Moved to methods above
+    # session = _refresh_tokens()
     app()
 else:
-    session = _refresh_tokens()
+    # Moved to methods above 
+    # session = _refresh_tokens()
     app()

--- a/cli.py
+++ b/cli.py
@@ -354,7 +354,8 @@ def _refresh_tokens():
     # access token in config is overriden stored in tok file in config dir
     session = CentralApi()
     central = session.central
-    central.token_store["path"] = _config_dir
+    # Commented out as I have no idea what it was doing. Maybe from a previous auth process? -mrose
+    # central.token_store["path"] = _config_dir
     token = central.loadToken()
     if token:
         # refresh token on every launch

--- a/lib/centralCLI/central.py
+++ b/lib/centralCLI/central.py
@@ -55,7 +55,7 @@ DEFAULT_TOKEN_STORE = {
 }
 
 
-def get_conn_from_file(logger: MyLogger = log):
+def get_conn_from_file(account_name, logger: MyLogger = log):
     """Creates an instance of class`pycentral.ArubaCentralBase` based on the information
     provided in the YAML/JSON file. \n
         * keyword central_info: A dict containing arguments as accepted by class`pycentral.ArubaCentralBase` \n
@@ -68,9 +68,9 @@ def get_conn_from_file(logger: MyLogger = log):
     :rtype: class:`pycentral.ArubaCentralBase`
     """
     conn = None
-    if "central_info" not in config.data:
-        exit(f"exiting... central_info missing from {config.file}")
-    central_info = config.data["central_info"]
+    if account_name not in config.data:
+        exit(f"exiting... {account_name} missing from {config.file}")
+    central_info = config.data[account_name]
     token_store = config.get("token_store", DEFAULT_TOKEN_STORE)
     ssl_verify = config.get("ssl_verify", True)
 
@@ -86,9 +86,9 @@ class CentralApi:
     log = log
 
     # def __init__(self, central: CentralApiAuth = CentralApiAuth()):
-    def __init__(self, central: ArubaCentralBase = None):
-        self.central = central or get_conn_from_file()
-        self.headers = {"authorization": f"Bearer {self.central.central_info['token']['access_token']}"}
+    def __init__(self, account_name):
+        self.central = get_conn_from_file(account_name)
+        # self.headers = {"authorization": f"Bearer {self.central.central_info['token']['access_token']}"}
         # Temp Refactor to use ArubaBaseClass without changing all my methods
         # self.central.get = self.get
         self.central.get = self.get
@@ -110,8 +110,8 @@ class CentralApi:
         :return: GET call response JSON
         :rtype: Python dict
         """
-        if headers is None:
-            headers = self.headers
+        # if headers is None:
+        #     headers = self.headers
         f_url = self.central.central_info["base_url"] + url
         # return Response(requests.get, f_url, params=params, headers=headers)
         return Response(self.central.requestUrl, f_url, params=params, headers=headers)


### PR DESCRIPTION
This PR adds the ability to have multiple Aruba Central accounts in the config.yaml file. You can then pass the --account <acount_name> options and it will then query against the account. If --account is not set, it will default to central_info; which will not break any existing config.yaml configurations.

This requires the `session = _refresh_tokens(account)` to be added to all existing and future app.commands() as it no longer runs before app.command. I've only added this def show() as I have not used the other app.commands() yet. 


`python3 cli.py show ap` 
Will show the APs from the account central_info

`python3 cli.py show ap --account sephora`
Will show the APs from the account sephora

Example config.yaml file.
`{
  "central_info": {
    "base_url": "https://internal-apigw.central.arubanetworks.com",
    "client_id": "fynDIEigjBGlhqnMhR6fghXXXXXXXXXXXXX",
    "client_secret": "<redacted>",
    "customer_id": "8c0dcXXXXXXXXXXXXX",
    "password": "<redacted>",
    "username": "user@somewhere.com"
  },
  "internal": {
    "base_url": "https://internal-apigw.central.arubanetworks.com",
    "client_id": "fynDIEigjBGlhqnMhR6fghXXXXXXXXXXXXX",
    "client_secret": "<redacted>",
    "customer_id": "8c0dcXXXXXXXXXXXXX",
    "password": "<redacted>",
    "username": "user@somewhere.com"
  },
  "multicare": {
    "base_url": "https://apigw-prod2.central.arubanetworks.com",
    "client_id": "0541b58af1dfae78917d7aXXXXXXXXXXXXX",
    "client_secret": "<redacted>",
    "customer_id": "50013XXXXXXXXXXXXX",
    "password": "<redacted>",
    "username": "user@somewhere.com"
  },
  "sephora": {
    "base_url": "https://apigw-prod2.central.arubanetworks.com",
    "client_id": "vbiqPxoj9AUO44RknD4wanXXXXXXXXXXXXX",
    "client_secret": "<redacted>",
    "customer_id": "5bf9fXXXXXXXXXXXXX",
    "password": "<redacted>",
    "username": "user@somewhere.com"
  },
  "starbucks": {
    "base_url": "https://apigw-prod2.central.arubanetworks.com",
    "client_id": "81RgTiQ1wxwL570OmjCAZwXXXXXXXXXXXXX",
    "client_secret": "<redacted>",
    "customer_id": "20011XXXXXXXXXXXXX",
    "password": "<redacted>",
    "username": "user@somewhere.com"
  },
  "token_store": {
    "path": "config",
    "type": "local"
  }
}`


