### PR TITLE
CLI output: Display content in a json or ASCII table with different formats

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -159,6 +159,7 @@ def bulk_edit(input_file: str = typer.Argument(None)):
 @app.command()
 def show(what: ShowLevel1 = typer.Argument(...), dev_type: str = typer.Argument(None), group: str = None,
         json: bool = typer.Option(False, "-j", is_flag=True, help="Output in JSON"),
+        output: str = typer.Option("simple", help="Output to table format"),
         account: str = typer.Option("central_info", help="Pass the account name from the config file")
         ):
     session = _refresh_tokens(account)
@@ -222,33 +223,39 @@ def show(what: ShowLevel1 = typer.Argument(...), dev_type: str = typer.Argument(
 
         if isinstance(data, str):
             typer.echo_via_pager(data)
+        # else:
+        #     _global_displayed = False
+        #     for _ in data:
+        #         if isinstance(_, list) and len(_) == 1:
+        #             typer.echo(_[0])
+
+        #         elif isinstance(_, dict):
+        #             if not _global_displayed and _.get("customer_id"):
+        #                 typer.echo(f"customer_id: {_['customer_id']}")
+        #                 typer.echo(f"customer_name: {_['customer_name']}")
+        #                 _global_displayed = True
+        #             typer.echo("--")
+        #             for k, v in _.items():
+        #                 # strip needless return keys from displayed output
+        #                 if k not in ["customer_id", "customer_name"]:
+        #                     typer.echo(f"{k}: {v}")
+        #         elif isinstance(_, str):
+        #             if isinstance(data, dict) and data.get(_):
+        #                 _key = typer.style(_, fg=typer.colors.CYAN)
+        #                 typer.echo(f"{_key}:")
+        #                 for k, v in sorted(data[_].items()):
+        #                     typer.echo(f"    {k}: {v}")
+        #             else:
+        #                 typer.echo(_)
+
+        # typer.echo("--\n")
+        if json == True:
+            tablefmt = "json"
+        elif output:
+            tablefmt = output
         else:
-            _global_displayed = False
-            for _ in data:
-                if isinstance(_, list) and len(_) == 1:
-                    typer.echo(_[0])
-
-                elif isinstance(_, dict):
-                    if not _global_displayed and _.get("customer_id"):
-                        typer.echo(f"customer_id: {_['customer_id']}")
-                        typer.echo(f"customer_name: {_['customer_name']}")
-                        _global_displayed = True
-                    typer.echo("--")
-                    for k, v in _.items():
-                        # strip needless return keys from displayed output
-                        if k not in ["customer_id", "customer_name"]:
-                            typer.echo(f"{k}: {v}")
-                elif isinstance(_, str):
-                    if isinstance(data, dict) and data.get(_):
-                        _key = typer.style(_, fg=typer.colors.CYAN)
-                        typer.echo(f"{_key}:")
-                        for k, v in sorted(data[_].items()):
-                            typer.echo(f"    {k}: {v}")
-                    else:
-                        typer.echo(_)
-
-        typer.echo("--\n")
-
+            tablefmt = "simple"
+        typer.echo(utils.output(data, tablefmt))
 
 @app.command()
 def template(operation: TemplateLevel1 = typer.Argument(...),

--- a/cli.py
+++ b/cli.py
@@ -207,7 +207,7 @@ def show(what: ShowLevel1 = typer.Argument(...), dev_type: str = typer.Argument(
     data = None if not resp else eval_resp(resp)
 
     if data:
-        typer.echo("\n--")
+        # typer.echo("\n--")
         # Strip needless inconsistent json key from dict if present
         if isinstance(data, dict):
             data = data.get("data", data)

--- a/lib/centralCLI/utils.py
+++ b/lib/centralCLI/utils.py
@@ -14,6 +14,7 @@ import json
 import socket
 from io import StringIO
 from halo import Halo
+from tabulate import tabulate
 
 try:
     loc_user = os.getlogin()
@@ -327,3 +328,17 @@ class Utils:
         if sys.stdin.isatty():
             with Halo(text=spin_txt, spinner=spinner):
                 return function(*args, **kwargs)
+
+    def output(self, outdata, tablefmt):
+        # pprint(outdata, indent=4)
+        if tablefmt == "json":
+            from pygments import highlight, lexers, formatters
+            json_data = json.dumps(outdata, sort_keys=True, indent=2)
+            table_data = highlight(bytes(json_data, 'UTF-8'), lexers.JsonLexer(), formatters.Terminal256Formatter(style='solarized-dark'))
+        elif tablefmt:
+            # print(tabulate(outdata, headers="keys", tablefmt=tablefmt))
+            table_data = tabulate(outdata, headers="keys", tablefmt=tablefmt)
+        if tablefmt == "csv":
+        #TODO Add CSV output
+             pass
+        return table_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+pygments
+tabulate
 pycentral
 halo
 typer


### PR DESCRIPTION

JSON output
`cencli show ap --account sephora -j`

Formatted table defaulted to "simple"
`cencli show ap --account sephora`

Another format available
`cencli show ap --account sephora --output psql`
`cencli show ap --account sephora --output fancy_grid`
`cencli show ap --account sephora --output html`

Other formats:
"plain"
"simple"
"github"
"grid"
"fancy_grid"
"pipe"
"orgtbl"
"jira"
"presto"
"pretty"
"psql"
"rst"
"mediawiki"
"moinmoin"
"youtrack"
"html"
"latex"
"latex_raw"
"latex_booktabs"
"textile"

