### PR TITLE
Use os environment vars for DEBUG and ACCOUNT

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7,8 +7,7 @@ import typer
 from lib.centralCLI.central import CentralApi, BuildCLI, utils, config, log
 
 # from pathlib import Path
-# import os
-
+from os import environ
 
 SPIN_TXT_AUTH = "Establishing Session with Aruba Central API Gateway..."
 SPIN_TXT_CMDS = "Sending Commands to Aruba Central API Gateway..."
@@ -396,8 +395,12 @@ def _refresh_tokens(account_name: str) -> CentralApi:
     return session
 
 
-# extract account from arguments
-account = "central_info"
+# extract account from arguments or environment variables
+if environ.get('ARUBACLI_ACCOUNT') is None:
+    account = "central_info"
+else:
+    account = environ.get('ARUBACLI_ACCOUNT')
+
 if "--account" in sys.argv:
     idx = sys.argv.index("--account")
     for i in range(idx, idx + 2):
@@ -409,10 +412,11 @@ if account not in config.data:
                f"The specified account: '{account}' not defined in config.")
 
 # debug flag ~ additional loggin, and all logs are echoed to tty
-if "--debug" in sys.argv:
-    config.DEBUG = True
-    log.setLevel(10)  # DEBUG
-    _ = sys.argv.pop(sys.argv.index("--debug"))
+if ("--debug" in sys.argv) or (environ.get('ARUBACLI_DEBUG') == "1"):
+    config.DEBUG = log.DEBUG = log.show = True
+    log.setLevel("DEBUG")  # DEBUG
+    if "--debug" in sys.argv:
+        _ = sys.argv.pop(sys.argv.index("--debug"))
 
 log.debug(" ".join(sys.argv))
 session = _refresh_tokens(account)

--- a/lib/centralCLI/utils.py
+++ b/lib/centralCLI/utils.py
@@ -337,7 +337,6 @@ class Utils:
             json_data = json.dumps(outdata, sort_keys=True, indent=2)
             table_data = highlight(bytes(json_data, 'UTF-8'), lexers.JsonLexer(), formatters.Terminal256Formatter(style='solarized-dark'))
         elif tablefmt:
-            # print(tabulate(outdata, headers="keys", tablefmt=tablefmt))
             table_data = tabulate(outdata, headers="keys", tablefmt=tablefmt)
         if tablefmt == "csv":
         #TODO Add CSV output


### PR DESCRIPTION

ARUBACLI_DEBUG=1
ARUBACLI_ACCOUNT=<account_profile>

Eliminates the need to pass each time you run the command.