### PR TITLE
vscode debugger args work-around. Response object enhancements, output tweak

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,29 +8,26 @@
           "type": "promptString",
           "id": "cliArgs",
           "description": "Select Arguments",
-        //   "default": "show gateway"
-        //   "default": "show ap --group Branch1"
-          "default": "show switches --yaml --outfile switches.yaml"
-        //   "default": "show ap --group Branch1"
-        //   "default": "batch --key test-acl"
+          // The default is updated automatically by the script, could not get vscode debugger to do it.
+          "default": "show sites"  // VSC_PREV_ARGS
         },
       ],
     "configurations": [
         {
-            "name": "DEVCLI interactive arg selection",
+            "name": "cli interactive arg selection",
             "type": "python",
             "request": "launch",
-            "program": "devcli.py",
+            "program": "cli.py",
             "console": "integratedTerminal",
             "justMyCode": false,
             "env": {"BETTER_EXCEPTIONS": "1"},
             "args": ["${input:cliArgs}"]
         },
         {
-            "name": "cli interactive arg selection",
+            "name": "DEVCLI interactive arg selection",
             "type": "python",
             "request": "launch",
-            "program": "cli.py",
+            "program": "devcli.py",
             "console": "integratedTerminal",
             "justMyCode": false,
             "env": {"BETTER_EXCEPTIONS": "1"},
@@ -45,6 +42,8 @@
             "justMyCode": false,
             "args": ["${input:cliArgs}"]
         },
+        // One of many previous attempts to get args from environment/.env file etc
+        // could not get it to work.  Not via debugger (even with "envFile": "${workspaceFolder}/.env",)
         {
             "name": "cli interactive arg selection WIP",
             "type": "python",

--- a/.vscode/launch.json.bak
+++ b/.vscode/launch.json.bak
@@ -1,0 +1,109 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "inputs": [
+        {
+          "type": "promptString",
+          "id": "cliArgs",
+          "description": "Select Arguments",
+          // The default is updated automatically by the script, could not get vscode debugger to do it.
+          "default": "show groups"  // VSC_PREV_ARGS
+        },
+      ],
+    "configurations": [
+        {
+            "name": "cli interactive arg selection",
+            "type": "python",
+            "request": "launch",
+            "program": "cli.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {"BETTER_EXCEPTIONS": "1"},
+            "args": ["${input:cliArgs}"]
+        },
+        {
+            "name": "DEVCLI interactive arg selection",
+            "type": "python",
+            "request": "launch",
+            "program": "devcli.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {"BETTER_EXCEPTIONS": "1"},
+            "args": ["${input:cliArgs}"]
+        },
+        {
+            "name": "ana-cli interactive arg selection",
+            "type": "python",
+            "request": "launch",
+            "program": "main.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": ["${input:cliArgs}"]
+        },
+        // One of many previous attempts to get args from environment/.env file etc
+        // could not get it to work.  Not via debugger (even with "envFile": "${workspaceFolder}/.env",)
+        {
+            "name": "cli interactive arg selection WIP",
+            "type": "python",
+            "request": "launch",
+            "program": "cli.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "preLaunchTask": "central cli arguments",
+            "args": ["${env:$PREV_ARGS}"]
+        },
+        {
+            "name": "Python: central.py bulk-edit",
+            "type": "python",
+            "request": "launch",
+            "program": "lib/centralCLI/central.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "bulk-edit"
+            ]
+        },
+        {
+            "name": "Python: cli.py interactive",
+            "type": "python",
+            "request": "launch",
+            "program": "cli.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "${input:cliArgs}"
+            ]
+        },
+        {
+            "name": "Python: cli.py bulk-edit",
+            "type": "python",
+            "request": "launch",
+            "program": "cli.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "bulk-edit"
+            ]
+        },
+        {
+            "name": "Python: cli.py show dev gateways",
+            "type": "python",
+            "request": "launch",
+            "program": "cli.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "show", "devices", "gateways"
+            ]
+        },
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,31 +4,24 @@
     // sed -i 's/"default": .*/"default": "show poop"/' .vscode/launch.json
     "tasks": [
       {
+        "label": "pre-get-args",
+        "type": "shell",
+        "command": "[[ -f ${workspaceFolder}/.vscode/vscargs.sh ]] && echo found vscargs && . ${workspaceFolder}/.vscode/vscargs.sh && echo Source Success && export VSC_PREV_ARGS=${env:VSC_PREV_ARGS} || echo Something went wrong"
+      },
+      {
+        "label": "post-export-args",
+        "type": "shell",
+        "command": "echo VSC_PREV_ARGS: $VSC_PREV_ARGS"
+      },
+      {
         "label": "central cli arguments",
         "type": "shell",
-        // "command": "echo ${workspaceFolder}/.vscode/envvars; read -p 'Press Enter To Continue'"
         "command": "[ -f ${workspaceFolder}/.vscode/envvars ] && . ${workspaceFolder}/.vscode/envvars; echo export PREV_ARGS=\\'${input:command}\\' > ${workspaceFolder}/.vscode/envvars"
-        // "command": "echo export PREV_ARGS=\\'${input:command}\\' > ${workspaceFolder}/.vscode/envvars"
-        // "command": "export PREV_ARGS=(${input:command}); echo ${PREV_ARGS[@]}; sleep 5"
-        // ...
       },
       {
-        "label": "stash cur arg",
+        "label": "ECHO",
         "type": "shell",
-        // "command": "echo ${workspaceFolder}/.vscode/envvars; read -p 'Press Enter To Continue'"
-        "command": "echo ${args}"
-        // "command": "echo export PREV_ARGS=\\'${input:command}\\' > ${workspaceFolder}/.vscode/envvars"
-        // "command": "echo export PREV_ARGS=\\'${input:command}\\' > ${workspaceFolder}/.vscode/envvars"
-        // "command": "export PREV_ARGS=(${input:command}); echo ${PREV_ARGS[@]}; sleep 5"
-        // ...
-      },
-      {
-        "label": "get prev args",
-        "type": "shell",
-        // "command": "echo ${workspaceFolder}/.vscode/envvars; read -p 'Press Enter To Continue'"
-        "command": "[ -f ${workspaceFolder}/.vscode/envvars ] && . ${workspaceFolder}/.vscode/envvars"
-        // "command": "export PREV_ARGS=(${input:command}); echo ${PREV_ARGS[@]}; sleep 5"
-        // ...
+        "command": "echo ${env:VSC_PREV_ARGS} ${workspaceFolder}",
       }
     ],
     "inputs": [

--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,7 @@ from os import environ
 from pathlib import Path
 from typing import List
 
+import sys
 import typer
 
 from lib.centralCLI import config, log, utils
@@ -11,13 +12,13 @@ from lib.centralCLI.central import BuildCLI, CentralApi
 from lib.centralCLI.constants import (ShowArgs, SortOptions, StatusOptions,
                                       arg_to_what, devices)
 
-print("All Done")
-
 STRIP_KEYS = ["data", "devices", "mcs", "group", "clients", "sites", "switches", "aps"]
 SPIN_TXT_AUTH = "Establishing Session with Aruba Central API Gateway..."
 SPIN_TXT_CMDS = "Sending Commands to Aruba Central API Gateway..."
 SPIN_TXT_DATA = "Collecting Data from Aruba Central API Gateway..."
 tty = utils.tty
+
+app = typer.Typer()
 
 
 def get_arguments_from_import(import_file: str, key: str = None) -> list:
@@ -30,7 +31,8 @@ def get_arguments_from_import(import_file: str, key: str = None) -> list:
     Returns:
         list: updated sys.argv list.
     """
-    args = utils.read_yaml(import_file)
+    # args = utils.read_yaml(import_file)
+    args = config.get_config_data(Path(import_file))
     if key and key in args:
         args = args[key]
 
@@ -40,41 +42,68 @@ def get_arguments_from_import(import_file: str, key: str = None) -> list:
 
 
 # -- break up arguments passed as single string from vscode promptString --
-import sys  # NoQA
+def vscode_arg_handler():
+    try:
+        if len(sys.argv) > 1:
+            if " " in sys.argv[1] or not sys.argv[1]:
+                vsc_args = sys.argv.pop(1)
+                if vsc_args:
+                    if "\\'" in vsc_args:
+                        _loc = vsc_args.find("\\'")
+                        _before = vsc_args[:_loc - 1]
+                        _str_end = vsc_args.find("\\'", _loc + 1)
+                        sys.argv += _before.split()
+                        sys.argv += [f"{vsc_args[_loc + 2:_str_end]}"]
+                        sys.argv += vsc_args[_str_end + 2:].split()
+                    else:
+                        sys.argv += vsc_args.split()
 
-sys.argv[0] = 'cencli'
-try:
-    if len(sys.argv) > 1:
-        if " " in sys.argv[1] or not sys.argv[1]:
-            vsc_args = sys.argv.pop(1)
-            if vsc_args:
-                if "\\'" in vsc_args:
-                    _loc = vsc_args.find("\\'")
-                    _before = vsc_args[:_loc - 1]
-                    _str_end = vsc_args.find("\\'", _loc + 1)
-                    sys.argv += _before.split()
-                    sys.argv += [f"{vsc_args[_loc + 2:_str_end]}"]
-                    sys.argv += vsc_args[_str_end + 2:].split()
-                else:
-                    sys.argv += vsc_args.split()
+        if len(sys.argv) > 2:
+            _import_file, _import_key = None, None
+            if sys.argv[2].endswith((".yaml", ".yml", "json")):
+                _import_file = sys.argv.pop(2)
+                if not utils.valid_file(_import_file):
+                    if utils.valid_file(config.dir.joinpath(_import_file)):
+                        _import_file = config.dir.joinpath(_import_file)
 
-    if len(sys.argv) > 2:
-        _import_file, _import_key = None, None
-        if sys.argv[2].endswith((".yaml", ".yml")):
-            _import_file = sys.argv.pop(2)
-            if not utils.valid_file(_import_file):
-                if utils.valid_file(config.dir.joinpath(_import_file)):
-                    _import_file = config.dir.joinpath(_import_file)
+                if len(sys.argv) > 2:
+                    _import_key = sys.argv.pop(2)
 
-            if len(sys.argv) > 2:
-                _import_key = sys.argv.pop(2)
+                sys.argv = get_arguments_from_import(_import_file, key=_import_key)
 
-        sys.argv = get_arguments_from_import(_import_file, key=_import_key)
-except Exception:
-    pass
+    except Exception as e:
+        log.exception(f"Exception in vscode arg handler (arg split) {e.__class__}.{e}", show=True)
+        return
 
+    # update launch.json default if launched by vscode debugger
+    try:
+        launch_file = config.base_dir / ".vscode" / "launch.json"
+        launch_file_bak = config.base_dir / ".vscode" / "launch.json.bak"
+        if launch_file.is_file():
+            launch_data = launch_file.read_text()
+            launch_data = launch_data.splitlines()
+            for idx, line in enumerate(launch_data):
+                if "default" in line and "// VSC_PREV_ARGS" in line:
+                    _spaces = len(line) - len(line.lstrip(" "))
+                    new_line = f'{" ":{_spaces}}"default": "{" ".join(sys.argv[1:])}"  // VSC_PREV_ARGS'
+                    if line != new_line:
+                        log.debug(f"changing default arg for promptString:\n"
+                                  f"\t from: {line}\n"
+                                  f"\t to: {new_line}"
+                                  )
+                        launch_data[idx] = new_line
 
-app = typer.Typer()
+                        # backup launch.json only if backup doesn't exist already
+                        if not launch_file_bak.is_file():
+                            import shutil
+                            shutil.copy(launch_file, launch_file_bak)
+
+                        # update launch.json
+                        launch_file.write_text("\n".join(launch_data))
+
+    except Exception as e:
+        log.exception(f"Exception in vscode arg handler (launch.json update) {e.__class__}.{e}", show=True)
+        return
 
 
 class TemplateLevel1(str, Enum):
@@ -244,7 +273,7 @@ def show(what: ShowArgs = typer.Argument(..., metavar=f"[{f'|'.join(show_dev_opt
                 outfile = config.outdir / outfile
 
             print(
-                typer.style(f"\nWriting output to {outfile.resolve()}... ", fg="cyan"),
+                typer.style(f"\nWriting output to {outfile.relative_to(Path.cwd())}... ", fg="cyan"),
                 end=""
             )
             outfile.write_text(outdata.file)  # typer.unstyle(outdata) also works
@@ -354,6 +383,7 @@ def batch(import_file: str = typer.Argument(config.stored_tasks_file),
 def refresh_tokens():
     pass
 
+
 @app.command()
 def method_test(method: str = typer.Argument(...),
                 kwargs: List[str] = typer.Argument(None)
@@ -403,26 +433,28 @@ def _refresh_tokens(account_name: str) -> CentralApi:
     return session
 
 
+# ---- // RUN \\ ----
+if environ.get("TERM_PROGRAM") == "vscode":
+    vscode_arg_handler()
+
 # extract account from arguments or environment variables
-if environ.get('ARUBACLI_ACCOUNT') is None:
-    account = "central_info"
-else:
-    account = environ.get('ARUBACLI_ACCOUNT')
+account = environ.get('ARUBACLI_ACCOUNT', "central_info")
 
 if "--account" in sys.argv:
     idx = sys.argv.index("--account")
     for i in range(idx, idx + 2):
         account = sys.argv.pop(idx)
 
-
+# Abort if account
 if account not in config.data:
     typer.echo(f"{typer.style('ERROR:', fg=typer.colors.RED)} "
                f"The specified account: '{account}' not defined in config.")
+    raise typer.Exit(1)
 
-# debug flag ~ additional loggin, and all logs are echoed to tty
+# debug flag ~ additional logging, and all logs are echoed to tty
 if ("--debug" in sys.argv) or (environ.get('ARUBACLI_DEBUG') == "1"):
     config.DEBUG = log.DEBUG = log.show = True
-    log.setLevel("DEBUG")  # DEBUG
+    log.setLevel("DEBUG")
     if "--debug" in sys.argv:
         _ = sys.argv.pop(sys.argv.index("--debug"))
 

--- a/lib/centralCLI/central.py
+++ b/lib/centralCLI/central.py
@@ -395,7 +395,6 @@ class CentralApi:
         # resp = requests.post(self.central.vars["base_url"] + url, headers=headers, json=payload)
         return Response(self.post, url, payload=payload)
 
-
     def caasapi(self, group_dev: str, cli_cmds: list = None):
         if ":" in group_dev and len(group_dev) == 17:
             key = "node_name"

--- a/lib/centralCLI/constants.py
+++ b/lib/centralCLI/constants.py
@@ -26,6 +26,9 @@ class ShowArgs(str, Enum):
 
 devices = ["switch", "aps", "gateway", "mcd"]
 
+# wrapping keys from return for some calls that have no value
+STRIP_KEYS = ["data", "devices", "mcs", "group", "clients", "sites", "switches", "aps"]
+
 
 class ArgToWhat:
     def __init__(self):
@@ -37,7 +40,7 @@ class ArgToWhat:
         std set in the method invoking the API call.
         """
         self.gateway = self.gateways = "gateway"
-        self.ap = self.aps = self.iap = "aps"
+        self.aps = self.ap = self.iap = "aps"
         self.switch = self.switches = "switch"
         self.groups = self.group = "groups"
         self.site = self.sites = "sites"


### PR DESCRIPTION
can now address dict key as Response class attribute
    resp["output"]["site"] available via resp["site"] and resp.site
    Also works for 2nd level of output dict if 2nd level is a dict

Also (from prev commit)
```
if resp:
    returns a bool (resp.ok)
```
and `print(resp)` prints contents of self.output (the dict)
