### PR TITLE
Adds Caching and friendly identifier support

### DIFF
--- a/centralCLI/config.py
+++ b/centralCLI/config.py
@@ -21,7 +21,7 @@ class Config:
                 break
         self.bulk_edit_file = self.dir.joinpath("bulkedit.csv")
         self.stored_tasks_file = self.dir.joinpath("stored-tasks.yaml")
-        self.cache_file = self.dir.joinpath(".cache", "cache.yaml")
+        self.cache_file = self.dir.joinpath(".cache", "db.json")
         self.cache_dir = self.cache_file.parent
         self.data = self.get_config_data(self.file) or {}
         self.DEBUG = self.data.get("debug", os.getenv("DEBUG", False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests
 urllib3
 colorlog
 click_spinner
+colorama


### PR DESCRIPTION
Adds support for using friendly identifiers.  When launched if no cache exist or the local cache is > 2 hours old all devices and all sites will be collected in the background and stored locally.

This facilitates i.e. to show the template for a specific device: `show template 10.0.30.224`, or `show template bsmt-2930F` *and* `show template <serial-num>` vs just allowing by serial-num.

Instantiated: cache = Identifiers(session)
Then `_args = cache.get_dev_identifier(args)` will look for a match by name ip serial or mac and return the serial of any devices that match.  Currently returns the fist match in the event of multiple.  Plan is to return all matches and output for things like show commands, and display matches with an ambiguous error or confirmation for `do` actions.

Also likely only works for `show template` until the next merge. 
