### PR TITLE
Auto-Refresh Token with user-input should be good

### DIFF
--- a/centralCLI/constants.py
+++ b/centralCLI/constants.py
@@ -115,3 +115,10 @@ class StatusOptions(str, Enum):
     Down = "Down"
     UP = "UP"
     DOWN = "DOWN"
+
+
+MESSAGES = {
+    "SPIN_TXT_AUTH": "Establishing Session with Aruba Central API Gateway...",
+    "SPIN_TXT_CMDS": "Sending Commands to Aruba Central API Gateway...",
+    "SPIN_TXT_DATA": "Collecting Data from Aruba Central API Gateway..."
+}

--- a/centralCLI/utils.py
+++ b/centralCLI/utils.py
@@ -172,15 +172,21 @@ class Utils:
             # with Halo(text=spin_txt, spinner=spinner):
             spin = None
             active_spinners = [t for t in threading.enumerate()[::-1] if t.name.startswith("spinner")]
-            if not active_spinners:
+            if active_spinners:
+                spin = active_spinners[0]._target.__self__
+                spin.text == spin_txt
+                spin.spinner == spinner
+            else:
                 spin = Halo(text=spin_txt, spinner=spinner)
                 spin.start()
                 threading.enumerate()[-1].name = spin._spinner_id = name
+
             r = function(*args, **kwargs)
+
             if spin:
                 spin.stop()
-            elif active_spinners:
-                _ = [t._target.__self__.stop() for t in active_spinners]
+            # elif active_spinners:
+            #     _ = [t._target.__self__.stop() for t in active_spinners]
                 # _ = [t._stop_spinner.set() for t in active_spinners]
                 # _ = [t._target.__self__._stop_spinner.set() for t in active_spinners]
                 # active_spinners[0]._target.__self__._stop_spinner.set()

--- a/cli.py
+++ b/cli.py
@@ -244,6 +244,11 @@ def show(what: ShowArgs = typer.Argument(..., metavar=f"[{f'|'.join(show_help)}]
         if what == "all":
             # resp = utils.spinner(SPIN_TXT_DATA, session.get_all_devices)
             resp = utils.spinner(SPIN_TXT_DATA, session.get_all_devicesv2, **params)
+        elif args:
+            serial = cache.get_dev_identifier(args)
+            resp = session.get_dev_details(what, serial)
+            if True not in [do_csv, do_json]:
+                do_yaml = True
         else:
             resp = utils.spinner(SPIN_TXT_DATA, session.get_devices, what, **params)
         # elif not group:
@@ -587,10 +592,10 @@ def method_test(method: str = typer.Argument(...),
 #      to update borked (cached) token.  internal can't reauth via OAUTH due to SSO
 def _refresh_tokens(account_name: str) -> CentralApi:
     # access token in config is overriden stored in tok file in config dir
-    if not config.DEBUG:
-        session = utils.spinner(SPIN_TXT_AUTH, CentralApi, account_name, name="init_CentralApi")
-    else:
-        session = CentralApi(account_name)
+    # if not config.DEBUG:
+    #     session = utils.spinner(SPIN_TXT_AUTH, CentralApi, account_name, name="init_CentralApi")
+    # else:
+    session = CentralApi(account_name)
 
     # central = session.central
 


### PR DESCRIPTION
Add show_dev_details `show switch idf1-sw2` ... Only tested with switch so far, but may work for others
Handle ArubaCentralBase trying to exit when no token
If the token is invalid and there is no token block in the config
user will be given opp to paste entire json from `Download Token`  in UI